### PR TITLE
Add message_ja lang file

### DIFF
--- a/Core/src/main/resources/lang/messages_ja.yml
+++ b/Core/src/main/resources/lang/messages_ja.yml
@@ -1,0 +1,37 @@
+Command:
+  List:
+    Desc: カスタムエンチャントリスト
+  Enchant:
+    Usage: <エンチャント名> <レベル>
+    Desc: 手に持っているものにエンチャントを付与します。
+    Done: '&aエンチャントが成功しました！'
+  Book:
+    Usage: <プレイヤー> <エンチャント名> <レベル>
+    Desc: 指定されたエンチャントが施されたエンチャント本を発行する
+    Done: '&6%player_display_name%&7に&6%enchant%&7のエンチャント本を与えました。'
+  TierBook:
+    Usage: <プレーヤー> <ランク> <レベル>
+    Desc: 指定されたランクの任意のエンチャントが施されたエンチャント本を発行する
+    Error: '&cそのようなランクはありません。'
+    Done: '&6%player_name%&7に&6%tier_name%&7ランクのエンチャントブックを与えました。'
+Error:
+  NoEnchant: '&c指定されたエンチャントは存在しません'
+FitItemType:
+  HELMET: ヘルメット
+  CHESTPLATE: チェストプレート
+  LEGGINGS: レギンス
+  BOOTS: ブーツ
+  ELYTRA: エリトラ
+  WEAPON: ウェポン
+  TOOL: ツール
+  ARMOR: アーマー
+  UNIVERSAL: 共通
+  SWORD: ソード
+  TRIDENT: トライデント
+  AXE: 斧
+  BOW: 弓
+  CROSSBOW: クロスボウ
+  HOE: クワ
+  PICKAXE: ツルハシ
+  SHOVEL: ショベル
+  FISHING_ROD: 釣り竿


### PR DESCRIPTION
## Overview

Hello.
I love this plugin.
I especially like the combination of double strike and EXP hunter.

I am Japanese and I play on Japan server.
The custom enchantment book is written in English and I would like to change it to Japanese.
For now, I will give you something to make only the message in Japanese.

It is currently hard coded and I would like to be able to manage the lang someday.

I will try to do it myself when I have time.

Thank you very much.