### PR TITLE
feat: remove swimming requirement

### DIFF
--- a/Core/src/main/java/su/nightexpress/excellentenchants/enchantment/armor/WaterBreathingEnchant.java
+++ b/Core/src/main/java/su/nightexpress/excellentenchants/enchantment/armor/WaterBreathingEnchant.java
@@ -30,6 +30,6 @@ public class WaterBreathingEnchant extends GameEnchantment implements PassiveEnc
 
     @Override
     public boolean onTrigger(@NotNull LivingEntity entity, @NotNull ItemStack item, int level) {
-        return entity.isSwimming() && this.addPotionEffect(entity, level);
+        return this.addPotionEffect(entity, level);
     }
 }


### PR DESCRIPTION
Removing the requirement of swimming from the Aquaman (WaterBreathing) enchant allows plugins (ie. Origins-Reborn) that force players to be aquatic to breath out of water using the enchant.

It does not break any functionality while functionally being the same as other enchantments like Sonic (SpeedyEnchant)