### PR TITLE
Updated for 26.1.2 compatibility

### DIFF
--- a/API/pom.xml
+++ b/API/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ExcellentEnchants</artifactId>
         <groupId>su.nightexpress.excellentenchants</groupId>
-        <version>5.4.1</version>
+        <version>5.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21.10-R0.1-SNAPSHOT</version>
+            <version>26.1.2.build.51-beta</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/API/pom.xml
+++ b/API/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ExcellentEnchants</artifactId>
         <groupId>su.nightexpress.excellentenchants</groupId>
-        <version>5.4.2</version>
+        <version>5.4.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/API/src/main/java/su/nightexpress/excellentenchants/api/item/ItemSetDefaults.java
+++ b/API/src/main/java/su/nightexpress/excellentenchants/api/item/ItemSetDefaults.java
@@ -23,6 +23,7 @@ public enum ItemSetDefaults {
     HOE(tagLookup -> ItemSet.buildByName("hoe", tagLookup.getHoes()).slots(EquipmentSlot.HAND).name("Hoe").build()),
     PICKAXE(tagLookup -> ItemSet.buildByName("pickaxe", tagLookup.getPickaxes()).slots(EquipmentSlot.HAND).name("Pickaxe").build()),
     SHOVEL(tagLookup -> ItemSet.buildByName("shovel", tagLookup.getShovels()).slots(EquipmentSlot.HAND).name("Shovel").build()),
+    SPEAR(tagLookup -> ItemSet.buildByName("spear", tagLookup.getSpears()).slots(EquipmentSlot.HAND, EquipmentSlot.OFF_HAND).name("Spear").build()),
     TRIDENT(tagLookup -> ItemSet.buildByType("trident", Material.TRIDENT).slots(EquipmentSlot.HAND, EquipmentSlot.OFF_HAND).name("Trident").build()),
     BOW(tagLookup -> ItemSet.buildByType("bow", Material.BOW).slots(EquipmentSlot.HAND, EquipmentSlot.OFF_HAND).name("Bow").build()),
     CROSSBOW(tagLookup -> ItemSet.buildByType("crossbow", Material.CROSSBOW).slots(EquipmentSlot.HAND, EquipmentSlot.OFF_HAND).name("Crossbow").build()),
@@ -105,6 +106,7 @@ public enum ItemSetDefaults {
         Set<String> materials = new HashSet<>();
         materials.addAll(tagLookup.getAxes());
         materials.addAll(tagLookup.getSwords());
+        materials.addAll(tagLookup.getSpears());
         materials.add(Material.BOW.name());
         materials.add(Material.CROSSBOW.name());
         materials.add(Material.TRIDENT.name());

--- a/API/src/main/java/su/nightexpress/excellentenchants/bridge/ItemTagLookup.java
+++ b/API/src/main/java/su/nightexpress/excellentenchants/bridge/ItemTagLookup.java
@@ -18,6 +18,11 @@ public interface ItemTagLookup {
 
     @NotNull Set<String> getSwords();
 
+    @NotNull
+    default Set<String> getSpears() {
+        return Set.of();
+    }
+
     @NotNull Set<String> getAxes();
 
     @NotNull Set<String> getHoes();

--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ExcellentEnchants</artifactId>
         <groupId>su.nightexpress.excellentenchants</groupId>
-        <version>5.4.1</version>
+        <version>5.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21.10-R0.1-SNAPSHOT</version>
+            <version>26.1.2.build.51-beta</version>
             <scope>provided</scope>
         </dependency>
 
@@ -42,43 +42,49 @@
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>API</artifactId>
-            <version>5.4.1</version>
+            <version>5.4.2</version>
         </dependency>
 
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>spigot-1.21.11</artifactId>
-            <version>5.4.1</version>
+            <version>5.4.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>su.nightexpress.excellentenchants</groupId>
+            <artifactId>spigot-26.1.2</artifactId>
+            <version>5.4.2</version>
         </dependency>
 
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>MC_1_21_10</artifactId>
-            <version>5.4.1</version>
+            <version>5.4.2</version>
         </dependency>
 
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>MC_1_21_8</artifactId>
-            <version>5.4.1</version>
+            <version>5.4.2</version>
         </dependency>
 
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>tooltip-packetevents</artifactId>
-            <version>5.4.1</version>
+            <version>5.4.2</version>
         </dependency>
 
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>tooltip-protocollib</artifactId>
-            <version>5.4.1</version>
+            <version>5.4.2</version>
         </dependency>
 
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>compat-mythicmobs</artifactId>
-            <version>5.4.1</version>
+            <version>5.4.2</version>
         </dependency>
     </dependencies>
 

--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ExcellentEnchants</artifactId>
         <groupId>su.nightexpress.excellentenchants</groupId>
-        <version>5.4.2</version>
+        <version>5.4.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -42,49 +42,49 @@
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>API</artifactId>
-            <version>5.4.2</version>
+            <version>5.4.3</version>
         </dependency>
 
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>spigot-1.21.11</artifactId>
-            <version>5.4.2</version>
+            <version>5.4.3</version>
         </dependency>
 
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>spigot-26.1.2</artifactId>
-            <version>5.4.2</version>
+            <version>5.4.3</version>
         </dependency>
 
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>MC_1_21_10</artifactId>
-            <version>5.4.2</version>
+            <version>5.4.3</version>
         </dependency>
 
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>MC_1_21_8</artifactId>
-            <version>5.4.2</version>
+            <version>5.4.3</version>
         </dependency>
 
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>tooltip-packetevents</artifactId>
-            <version>5.4.2</version>
+            <version>5.4.3</version>
         </dependency>
 
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>tooltip-protocollib</artifactId>
-            <version>5.4.2</version>
+            <version>5.4.3</version>
         </dependency>
 
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>compat-mythicmobs</artifactId>
-            <version>5.4.2</version>
+            <version>5.4.3</version>
         </dependency>
     </dependencies>
 

--- a/Core/src/main/java/su/nightexpress/excellentenchants/bridge/paper/PaperEnchantsBootstrap.java
+++ b/Core/src/main/java/su/nightexpress/excellentenchants/bridge/paper/PaperEnchantsBootstrap.java
@@ -39,9 +39,12 @@ import su.nightexpress.nightcore.util.Lists;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class PaperEnchantsBootstrap implements PluginBootstrap {
+
+    private static final boolean HAS_SPECIAL_TRADE_TAGS = hasSpecialTradeTags();
 
     @NotNull
     private TagKey<ItemType> customItemTag(@NotNull String name) {
@@ -176,8 +179,8 @@ public class PaperEnchantsBootstrap implements PluginBootstrap {
 
                 // Any enchantment can be tradable (on enchanted books).
                 if (distribution.isTradable() && distributionConfig.isTradingEnabled()) {
-                    distribution.getTrades().forEach(tradeType -> {
-                        registrar.addToTag(getTradeKey(tradeType), list);
+                    distribution.getTrades().stream().map(PaperEnchantsBootstrap::getTradeKey).collect(Collectors.toSet()).forEach(tradeKey -> {
+                        registrar.addToTag(tradeKey, list);
                     });
                     registrar.addToTag(EnchantmentTagKeys.TRADEABLE, list);
                 }
@@ -199,21 +202,36 @@ public class PaperEnchantsBootstrap implements PluginBootstrap {
 
     @NotNull
     private static TagKey<Enchantment> getTradeKey(@NotNull TradeType tradeType) {
+        return EnchantmentTagKeys.create(Key.key(Key.MINECRAFT_NAMESPACE, "trades/" + getTradePath(tradeType)));
+    }
+
+    @NotNull
+    private static String getTradePath(@NotNull TradeType tradeType) {
         return switch (tradeType) {
-            case DESERT_COMMON -> EnchantmentTagKeys.TRADES_DESERT_COMMON;
-            case DESERT_SPECIAL -> EnchantmentTagKeys.TRADES_DESERT_SPECIAL;
-            case PLAINS_COMMON -> EnchantmentTagKeys.TRADES_PLAINS_COMMON;
-            case PLAINS_SPECIAL -> EnchantmentTagKeys.TRADES_PLAINS_SPECIAL;
-            case SAVANNA_COMMON -> EnchantmentTagKeys.TRADES_SAVANNA_COMMON;
-            case SAVANNA_SPECIAL -> EnchantmentTagKeys.TRADES_SAVANNA_SPECIAL;
-            case JUNGLE_COMMON -> EnchantmentTagKeys.TRADES_JUNGLE_COMMON;
-            case JUNGLE_SPECIAL -> EnchantmentTagKeys.TRADES_JUNGLE_SPECIAL;
-            case SNOW_COMMON -> EnchantmentTagKeys.TRADES_SNOW_COMMON;
-            case SNOW_SPECIAL -> EnchantmentTagKeys.TRADES_SNOW_SPECIAL;
-            case SWAMP_COMMON -> EnchantmentTagKeys.TRADES_SWAMP_COMMON;
-            case SWAMP_SPECIAL -> EnchantmentTagKeys.TRADES_SWAMP_SPECIAL;
-            case TAIGA_COMMON -> EnchantmentTagKeys.TRADES_TAIGA_COMMON;
-            case TAIGA_SPECIAL -> EnchantmentTagKeys.TRADES_TAIGA_SPECIAL;
+            case DESERT_COMMON -> "desert_common";
+            case DESERT_SPECIAL -> HAS_SPECIAL_TRADE_TAGS ? "desert_special" : "desert_common";
+            case PLAINS_COMMON -> "plains_common";
+            case PLAINS_SPECIAL -> HAS_SPECIAL_TRADE_TAGS ? "plains_special" : "plains_common";
+            case SAVANNA_COMMON -> "savanna_common";
+            case SAVANNA_SPECIAL -> HAS_SPECIAL_TRADE_TAGS ? "savanna_special" : "savanna_common";
+            case JUNGLE_COMMON -> "jungle_common";
+            case JUNGLE_SPECIAL -> HAS_SPECIAL_TRADE_TAGS ? "jungle_special" : "jungle_common";
+            case SNOW_COMMON -> "snow_common";
+            case SNOW_SPECIAL -> HAS_SPECIAL_TRADE_TAGS ? "snow_special" : "snow_common";
+            case SWAMP_COMMON -> "swamp_common";
+            case SWAMP_SPECIAL -> HAS_SPECIAL_TRADE_TAGS ? "swamp_special" : "swamp_common";
+            case TAIGA_COMMON -> "taiga_common";
+            case TAIGA_SPECIAL -> HAS_SPECIAL_TRADE_TAGS ? "taiga_special" : "taiga_common";
         };
+    }
+
+    private static boolean hasSpecialTradeTags() {
+        try {
+            EnchantmentTagKeys.class.getField("TRADES_DESERT_SPECIAL");
+            return true;
+        }
+        catch (NoSuchFieldException exception) {
+            return false;
+        }
     }
 }

--- a/Core/src/main/java/su/nightexpress/excellentenchants/bridge/paper/PaperItemTagLookup.java
+++ b/Core/src/main/java/su/nightexpress/excellentenchants/bridge/paper/PaperItemTagLookup.java
@@ -1,8 +1,10 @@
 package su.nightexpress.excellentenchants.bridge.paper;
 
 import io.papermc.paper.registry.keys.tags.ItemTypeTagKeys;
+import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.tag.TagKey;
 import io.papermc.paper.tag.PostFlattenTagRegistrar;
+import net.kyori.adventure.key.Key;
 import org.bukkit.inventory.ItemType;
 import org.jetbrains.annotations.NotNull;
 import su.nightexpress.excellentenchants.bridge.ItemTagLookup;
@@ -56,6 +58,12 @@ public class PaperItemTagLookup implements ItemTagLookup {
 
     @Override
     @NotNull
+    public Set<String> getSpears() {
+        return this.fromRegistry(TagKey.create(RegistryKey.ITEM, Key.key(Key.MINECRAFT_NAMESPACE, "spears")));
+    }
+
+    @Override
+    @NotNull
     public Set<String> getAxes() {
         return this.fromRegistry(ItemTypeTagKeys.AXES);
     }
@@ -80,6 +88,8 @@ public class PaperItemTagLookup implements ItemTagLookup {
 
     @NotNull
     private Set<String> fromRegistry(@NotNull TagKey<ItemType> key) {
+        if (!this.registrar.hasTag(key)) return Set.of();
+
         return this.registrar.getTag(key).stream().map(typedKey -> typedKey.key().value()).collect(Collectors.toSet());
     }
 }

--- a/Core/src/main/java/su/nightexpress/excellentenchants/bridge/spigot/SpigotEnchantsBootstrap.java
+++ b/Core/src/main/java/su/nightexpress/excellentenchants/bridge/spigot/SpigotEnchantsBootstrap.java
@@ -11,6 +11,7 @@ import su.nightexpress.excellentenchants.enchantment.EnchantCatalog;
 import su.nightexpress.excellentenchants.enchantment.EnchantRegistry;
 import su.nightexpress.excellentenchants.nms.mc_1_21_10.RegistryHack_1_21_10;
 import su.nightexpress.excellentenchants.nms.mc_1_21_8.RegistryHack_1_21_8;
+import su.nightexpress.excellentenchants.nms.mc_26_1_2.RegistryHack_26_1_2;
 import su.nightexpress.nightcore.util.Version;
 
 import java.nio.file.Path;
@@ -22,6 +23,7 @@ public class SpigotEnchantsBootstrap {
             case MC_1_21_8 -> new RegistryHack_1_21_8(plugin);
             case MC_1_21_10 -> new RegistryHack_1_21_10(plugin);
             case MC_1_21_11 -> new RegistryHack_1_21_11(plugin);
+            case MC_26_1_2 -> new RegistryHack_26_1_2(plugin);
             default -> null;
         };
 

--- a/Core/src/main/java/su/nightexpress/excellentenchants/bridge/spigot/SpigotItemTagLookup.java
+++ b/Core/src/main/java/su/nightexpress/excellentenchants/bridge/spigot/SpigotItemTagLookup.java
@@ -5,6 +5,7 @@ import org.bukkit.Tag;
 import org.jetbrains.annotations.NotNull;
 import su.nightexpress.excellentenchants.bridge.ItemTagLookup;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -48,6 +49,12 @@ public class SpigotItemTagLookup implements ItemTagLookup {
 
     @Override
     @NotNull
+    public Set<String> getSpears() {
+        return fromTag("ITEMS_SPEARS");
+    }
+
+    @Override
+    @NotNull
     public Set<String> getAxes() {
         return fromTag(Tag.ITEMS_AXES);
     }
@@ -73,5 +80,19 @@ public class SpigotItemTagLookup implements ItemTagLookup {
     @NotNull
     private Set<String> fromTag(@NotNull Tag<Material> tag) {
         return tag.getValues().stream().map(Enum::name).collect(Collectors.toSet());
+    }
+
+    @SuppressWarnings("unchecked")
+    @NotNull
+    private static Set<String> fromTag(@NotNull String fieldName) {
+        try {
+            Object tag = Tag.class.getField(fieldName).get(null);
+            if (tag instanceof Tag<?> bukkitTag) {
+                return ((Tag<Material>) bukkitTag).getValues().stream().map(Enum::name).collect(Collectors.toSet());
+            }
+        }
+        catch (ReflectiveOperationException ignored) {
+        }
+        return Collections.emptySet();
     }
 }

--- a/Core/src/main/java/su/nightexpress/excellentenchants/enchantment/EnchantCatalog.java
+++ b/Core/src/main/java/su/nightexpress/excellentenchants/enchantment/EnchantCatalog.java
@@ -620,6 +620,7 @@ public enum EnchantCatalog implements EnchantCatalogEntry {
                     value.load(enchantsDir, itemSetRegistry);
                 }
                 catch (IllegalStateException exception) {
+                    value.disabled = true;
                     onError.accept(value, exception);
                 }
             }

--- a/MC_1_21_10/pom.xml
+++ b/MC_1_21_10/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>su.nightexpress.excellentenchants</groupId>
         <artifactId>ExcellentEnchants</artifactId>
-        <version>5.4.2</version>
+        <version>5.4.3</version>
     </parent>
 
     <artifactId>MC_1_21_10</artifactId>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>API</artifactId>
-            <version>5.4.2</version>
+            <version>5.4.3</version>
         </dependency>
     </dependencies>
 

--- a/MC_1_21_10/pom.xml
+++ b/MC_1_21_10/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>su.nightexpress.excellentenchants</groupId>
         <artifactId>ExcellentEnchants</artifactId>
-        <version>5.4.1</version>
+        <version>5.4.2</version>
     </parent>
 
     <artifactId>MC_1_21_10</artifactId>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>API</artifactId>
-            <version>5.4.1</version>
+            <version>5.4.2</version>
         </dependency>
     </dependencies>
 

--- a/MC_1_21_10/src/main/java/su/nightexpress/excellentenchants/nms/mc_1_21_10/RegistryHack_1_21_10.java
+++ b/MC_1_21_10/src/main/java/su/nightexpress/excellentenchants/nms/mc_1_21_10/RegistryHack_1_21_10.java
@@ -66,47 +66,41 @@ public class RegistryHack_1_21_10 implements RegistryHack {
         this.plugin = plugin;
     }
 
-    @NotNull
-    private static ResourceLocation customResourceLocation(@NotNull String value) {
+    private static ResourceLocation customResourceLocation(String value) {
         return CraftNamespacedKey.toMinecraft(EnchantsKeys.create(value));
     }
 
-    private static <T> TagKey<T> customTagKey(@NotNull Registry<T> registry, @NotNull String name) {
+    private static <T> TagKey<T> customTagKey(Registry<T> registry, String name) {
         return TagKey.create(registry.key(), customResourceLocation(name));
     }
 
-    @NotNull
-    private static ResourceKey<Enchantment> customEnchantKey(@NotNull String name) {
+    private static ResourceKey<Enchantment> customEnchantKey(String name) {
         ResourceLocation location = customResourceLocation(name);
 
         return ResourceKey.create(ENCHANTS.key(), location);
     }
 
-    @NotNull
-    private static ResourceKey<Enchantment> enchantKey(@NotNull String name) {
+    private static ResourceKey<Enchantment> enchantKey(String name) {
         ResourceLocation location = ResourceLocation.parse(name);
 
         return ResourceKey.create(ENCHANTS.key(), location);
     }
 
-    private static TagKey<Item> customItemsTag(@NotNull String path) {
+    private static TagKey<Item> customItemsTag(String path) {
         return TagKey.create(ITEMS.key(), customResourceLocation(path));
     }
 
     @SuppressWarnings("unchecked")
-    @NotNull
-    private static <T> Map<TagKey<T>, HolderSet.Named<T>> getFrozenTags(@NotNull MappedRegistry<T> registry) {
+    private static <T> Map<TagKey<T>, HolderSet.Named<T>> getFrozenTags(MappedRegistry<T> registry) {
         return (Map<TagKey<T>, HolderSet.Named<T>>) Reflex.getFieldValue(registry, REGISTRY_FROZEN_TAGS_FIELD);
     }
 
-    @NotNull
-    private static <T> Object getAllTags(@NotNull MappedRegistry<T> registry) {
+    private static <T> Object getAllTags(MappedRegistry<T> registry) {
         return Reflex.getFieldValue(registry, REGISTRY_ALL_TAGS_FIELD);
     }
 
     @SuppressWarnings("unchecked")
-    @NotNull
-    private static <T> Map<TagKey<T>, HolderSet.Named<T>> getTagsMap(@NotNull Object tagSet) {
+    private static <T> Map<TagKey<T>, HolderSet.Named<T>> getTagsMap(Object tagSet) {
         // new HashMap, because original is ImmutableMap.
         return new HashMap<>((Map<TagKey<T>, HolderSet.Named<T>>) Reflex.getFieldValue(tagSet, TAG_SET_MAP_FIELD));
     }
@@ -124,12 +118,12 @@ public class RegistryHack_1_21_10 implements RegistryHack {
         //this.displayTags();
     }
 
-    private static <T> void unfreeze(@NotNull MappedRegistry<T> registry) {
+    private static <T> void unfreeze(MappedRegistry<T> registry) {
         Reflex.setFieldValue(registry, "l", false);             // MappedRegistry#frozen
         Reflex.setFieldValue(registry, "m", new IdentityHashMap<>()); // MappedRegistry#unregisteredIntrusiveHolders
     }
 
-    private static <T> void freeze(@NotNull MappedRegistry<T> registry) {
+    private static <T> void freeze(MappedRegistry<T> registry) {
         // Get original TagSet object of the registry before unbound.
         // We MUST keep original TagSet object and only modify an inner map object inside it.
         // Otherwise it will throw an Network Error on client join because of 'broken' tags that were bound to other TagSet object.
@@ -163,7 +157,7 @@ public class RegistryHack_1_21_10 implements RegistryHack {
         Reflex.setFieldValue(registry, REGISTRY_ALL_TAGS_FIELD, tagSet);
     }
 
-    private static <T> void unbound(@NotNull MappedRegistry<T> registry) {
+    private static <T> void unbound(MappedRegistry<T> registry) {
         Class<?> tagSetClass = Reflex.safeInnerClass(MappedRegistry.class.getName(), "a");  // TagSet for PaperMC
 
         Method unboundMethod = Reflex.safeMethod(tagSetClass, TAG_SET_UNBOUND_METHOD);
@@ -230,7 +224,7 @@ public class RegistryHack_1_21_10 implements RegistryHack {
         return CraftEnchantment.minecraftToBukkit(enchantment);
     }
 
-    private void setupDistribution(@NotNull EnchantCatalogEntry entry, @NotNull DistributionSettings settings, @NotNull Holder.Reference<Enchantment> reference) {
+    private void setupDistribution(EnchantCatalogEntry entry, DistributionSettings settings, Holder.Reference<Enchantment> reference) {
         EnchantDistribution distribution = entry.getDistribution();
         boolean experimentalTrades = SERVER.getWorldData().enabledFeatures().contains(FeatureFlags.TRADE_REBALANCE);
 
@@ -286,18 +280,18 @@ public class RegistryHack_1_21_10 implements RegistryHack {
         }
     }
 
-    private void addInTag(@NotNull TagKey<Enchantment> tagKey, @NotNull Holder.Reference<Enchantment> reference) {
+    private void addInTag(TagKey<Enchantment> tagKey, Holder.Reference<Enchantment> reference) {
         modfiyTag(ENCHANTS, tagKey, reference, List::add);
     }
 
-    private void removeFromTag(@NotNull TagKey<Enchantment> tagKey, @NotNull Holder.Reference<Enchantment> reference) {
+    private void removeFromTag(TagKey<Enchantment> tagKey, Holder.Reference<Enchantment> reference) {
         modfiyTag(ENCHANTS, tagKey, reference, List::remove);
     }
 
-    private <T> void modfiyTag(@NotNull MappedRegistry<T> registry,
-                               @NotNull TagKey<T> tagKey,
-                               @NotNull Holder.Reference<T> reference,
-                               @NotNull BiConsumer<List<Holder<T>>, Holder.Reference<T>> consumer) {
+    private <T> void modfiyTag(MappedRegistry<T> registry,
+                               TagKey<T> tagKey,
+                               Holder.Reference<T> reference,
+                               BiConsumer<List<Holder<T>>, Holder.Reference<T>> consumer) {
 
         HolderSet.Named<T> holders = registry.get(tagKey).orElse(null);
         if (holders == null) {
@@ -330,8 +324,7 @@ public class RegistryHack_1_21_10 implements RegistryHack {
         //return getFrozenTags(ITEMS).get(customKey);
     }
 
-    @NotNull
-    private HolderSet.Named<Enchantment> createExclusiveSet(@NotNull String id) {
+    private HolderSet.Named<Enchantment> createExclusiveSet(String id) {
         TagKey<Enchantment> customKey = customTagKey(ENCHANTS, "exclusive_set/" + id);
         List<Holder<Enchantment>> holders = new ArrayList<>();
 
@@ -344,8 +337,7 @@ public class RegistryHack_1_21_10 implements RegistryHack {
 
 
 
-    @NotNull
-    private static TagKey<Enchantment> getTradeKey(@NotNull TradeType tradeType) {
+    private static TagKey<Enchantment> getTradeKey(TradeType tradeType) {
         return switch (tradeType) {
             case DESERT_COMMON -> EnchantmentTags.TRADES_DESERT_COMMON;
             case DESERT_SPECIAL -> EnchantmentTags.TRADES_DESERT_SPECIAL;
@@ -364,12 +356,11 @@ public class RegistryHack_1_21_10 implements RegistryHack {
         };
     }
 
-    @NotNull
-    private static Enchantment.Cost nmsCost(@NotNull EnchantCost cost) {
+    private static Enchantment.Cost nmsCost(EnchantCost cost) {
         return new Enchantment.Cost(cost.base(), cost.perLevel());
     }
 
-    private static EquipmentSlotGroup[] nmsSlots(@NotNull EquipmentSlot[] slots) {
+    private static EquipmentSlotGroup[] nmsSlots(EquipmentSlot[] slots) {
         EquipmentSlotGroup[] nmsSlots = new EquipmentSlotGroup[slots.length];
 
         for (int index = 0; index < nmsSlots.length; index++) {

--- a/MC_1_21_8/pom.xml
+++ b/MC_1_21_8/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>su.nightexpress.excellentenchants</groupId>
         <artifactId>ExcellentEnchants</artifactId>
-        <version>5.4.2</version>
+        <version>5.4.3</version>
     </parent>
 
     <artifactId>MC_1_21_8</artifactId>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>API</artifactId>
-            <version>5.4.2</version>
+            <version>5.4.3</version>
         </dependency>
     </dependencies>
 

--- a/MC_1_21_8/pom.xml
+++ b/MC_1_21_8/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>su.nightexpress.excellentenchants</groupId>
         <artifactId>ExcellentEnchants</artifactId>
-        <version>5.4.1</version>
+        <version>5.4.2</version>
     </parent>
 
     <artifactId>MC_1_21_8</artifactId>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>API</artifactId>
-            <version>5.4.1</version>
+            <version>5.4.2</version>
         </dependency>
     </dependencies>
 

--- a/MC_1_21_8/src/main/java/su/nightexpress/excellentenchants/nms/mc_1_21_8/RegistryHack_1_21_8.java
+++ b/MC_1_21_8/src/main/java/su/nightexpress/excellentenchants/nms/mc_1_21_8/RegistryHack_1_21_8.java
@@ -66,47 +66,41 @@ public class RegistryHack_1_21_8 implements RegistryHack {
         this.plugin = plugin;
     }
 
-    @NotNull
-    private static ResourceLocation customResourceLocation(@NotNull String value) {
+    private static ResourceLocation customResourceLocation(String value) {
         return CraftNamespacedKey.toMinecraft(EnchantsKeys.create(value));
     }
 
-    private static <T> TagKey<T> customTagKey(@NotNull Registry<T> registry, @NotNull String name) {
+    private static <T> TagKey<T> customTagKey(Registry<T> registry, String name) {
         return TagKey.create(registry.key(), customResourceLocation(name));
     }
 
-    @NotNull
-    private static ResourceKey<Enchantment> customEnchantKey(@NotNull String name) {
+    private static ResourceKey<Enchantment> customEnchantKey(String name) {
         ResourceLocation location = customResourceLocation(name);
 
         return ResourceKey.create(ENCHANTS.key(), location);
     }
 
-    @NotNull
-    private static ResourceKey<Enchantment> enchantKey(@NotNull String name) {
+    private static ResourceKey<Enchantment> enchantKey(String name) {
         ResourceLocation location = ResourceLocation.parse(name);
 
         return ResourceKey.create(ENCHANTS.key(), location);
     }
 
-    private static TagKey<Item> customItemsTag(@NotNull String path) {
+    private static TagKey<Item> customItemsTag(String path) {
         return TagKey.create(ITEMS.key(), customResourceLocation(path));
     }
 
     @SuppressWarnings("unchecked")
-    @NotNull
-    private static <T> Map<TagKey<T>, HolderSet.Named<T>> getFrozenTags(@NotNull MappedRegistry<T> registry) {
+    private static <T> Map<TagKey<T>, HolderSet.Named<T>> getFrozenTags(MappedRegistry<T> registry) {
         return (Map<TagKey<T>, HolderSet.Named<T>>) Reflex.getFieldValue(registry, REGISTRY_FROZEN_TAGS_FIELD);
     }
 
-    @NotNull
-    private static <T> Object getAllTags(@NotNull MappedRegistry<T> registry) {
+    private static <T> Object getAllTags(MappedRegistry<T> registry) {
         return Reflex.getFieldValue(registry, REGISTRY_ALL_TAGS_FIELD);
     }
 
     @SuppressWarnings("unchecked")
-    @NotNull
-    private static <T> Map<TagKey<T>, HolderSet.Named<T>> getTagsMap(@NotNull Object tagSet) {
+    private static <T> Map<TagKey<T>, HolderSet.Named<T>> getTagsMap(Object tagSet) {
         // new HashMap, because original is ImmutableMap.
         return new HashMap<>((Map<TagKey<T>, HolderSet.Named<T>>) Reflex.getFieldValue(tagSet, TAG_SET_MAP_FIELD));
     }
@@ -124,12 +118,12 @@ public class RegistryHack_1_21_8 implements RegistryHack {
         //this.displayTags();
     }
 
-    private static <T> void unfreeze(@NotNull MappedRegistry<T> registry) {
+    private static <T> void unfreeze(MappedRegistry<T> registry) {
         Reflex.setFieldValue(registry, "l", false);             // MappedRegistry#frozen
         Reflex.setFieldValue(registry, "m", new IdentityHashMap<>()); // MappedRegistry#unregisteredIntrusiveHolders
     }
 
-    private static <T> void freeze(@NotNull MappedRegistry<T> registry) {
+    private static <T> void freeze(MappedRegistry<T> registry) {
         // Get original TagSet object of the registry before unbound.
         // We MUST keep original TagSet object and only modify an inner map object inside it.
         // Otherwise it will throw an Network Error on client join because of 'broken' tags that were bound to other TagSet object.
@@ -163,7 +157,7 @@ public class RegistryHack_1_21_8 implements RegistryHack {
         Reflex.setFieldValue(registry, REGISTRY_ALL_TAGS_FIELD, tagSet);
     }
 
-    private static <T> void unbound(@NotNull MappedRegistry<T> registry) {
+    private static <T> void unbound(MappedRegistry<T> registry) {
         Class<?> tagSetClass = Reflex.safeInnerClass(MappedRegistry.class.getName(), "a");
         Method unboundMethod = Reflex.safeMethod(tagSetClass, TAG_SET_UNBOUND_METHOD);
         Object unboundTagSet = Reflex.invokeMethod(unboundMethod, registry); // new TagSet object.
@@ -229,7 +223,7 @@ public class RegistryHack_1_21_8 implements RegistryHack {
         return CraftEnchantment.minecraftToBukkit(enchantment);
     }
 
-    private void setupDistribution(@NotNull EnchantCatalogEntry entry, @NotNull DistributionSettings settings, @NotNull Holder.Reference<Enchantment> reference) {
+    private void setupDistribution(EnchantCatalogEntry entry, DistributionSettings settings, Holder.Reference<Enchantment> reference) {
         EnchantDistribution distribution = entry.getDistribution();
         boolean experimentalTrades = SERVER.getWorldData().enabledFeatures().contains(FeatureFlags.TRADE_REBALANCE);
 
@@ -285,18 +279,18 @@ public class RegistryHack_1_21_8 implements RegistryHack {
         }
     }
 
-    private void addInTag(@NotNull TagKey<Enchantment> tagKey, @NotNull Holder.Reference<Enchantment> reference) {
+    private void addInTag(TagKey<Enchantment> tagKey, Holder.Reference<Enchantment> reference) {
         modfiyTag(ENCHANTS, tagKey, reference, List::add);
     }
 
-    private void removeFromTag(@NotNull TagKey<Enchantment> tagKey, @NotNull Holder.Reference<Enchantment> reference) {
+    private void removeFromTag(TagKey<Enchantment> tagKey, Holder.Reference<Enchantment> reference) {
         modfiyTag(ENCHANTS, tagKey, reference, List::remove);
     }
 
-    private <T> void modfiyTag(@NotNull MappedRegistry<T> registry,
-                               @NotNull TagKey<T> tagKey,
-                               @NotNull Holder.Reference<T> reference,
-                               @NotNull BiConsumer<List<Holder<T>>, Holder.Reference<T>> consumer) {
+    private <T> void modfiyTag(MappedRegistry<T> registry,
+                               TagKey<T> tagKey,
+                               Holder.Reference<T> reference,
+                               BiConsumer<List<Holder<T>>, Holder.Reference<T>> consumer) {
 
         HolderSet.Named<T> holders = registry.get(tagKey).orElse(null);
         if (holders == null) {
@@ -329,8 +323,7 @@ public class RegistryHack_1_21_8 implements RegistryHack {
         //return getFrozenTags(ITEMS).get(customKey);
     }
 
-    @NotNull
-    private HolderSet.Named<Enchantment> createExclusiveSet(@NotNull String id) {
+    private HolderSet.Named<Enchantment> createExclusiveSet(String id) {
         TagKey<Enchantment> customKey = customTagKey(ENCHANTS, "exclusive_set/" + id);
         List<Holder<Enchantment>> holders = new ArrayList<>();
 
@@ -343,8 +336,7 @@ public class RegistryHack_1_21_8 implements RegistryHack {
 
 
 
-    @NotNull
-    private static TagKey<Enchantment> getTradeKey(@NotNull TradeType tradeType) {
+    private static TagKey<Enchantment> getTradeKey(TradeType tradeType) {
         return switch (tradeType) {
             case DESERT_COMMON -> EnchantmentTags.TRADES_DESERT_COMMON;
             case DESERT_SPECIAL -> EnchantmentTags.TRADES_DESERT_SPECIAL;
@@ -363,12 +355,11 @@ public class RegistryHack_1_21_8 implements RegistryHack {
         };
     }
 
-    @NotNull
-    private static Enchantment.Cost nmsCost(@NotNull EnchantCost cost) {
+    private static Enchantment.Cost nmsCost(EnchantCost cost) {
         return new Enchantment.Cost(cost.base(), cost.perLevel());
     }
 
-    private static EquipmentSlotGroup[] nmsSlots(@NotNull EquipmentSlot[] slots) {
+    private static EquipmentSlotGroup[] nmsSlots(EquipmentSlot[] slots) {
         EquipmentSlotGroup[] nmsSlots = new EquipmentSlotGroup[slots.length];
 
         for (int index = 0; index < nmsSlots.length; index++) {

--- a/README.md
+++ b/README.md
@@ -75,16 +75,17 @@
 
 ## Requirements
 
-You **must** have [NightCore](https://nightexpressdev.com/nightcore/) plugin installed to run **ExcellentEnchants**.
+You **must** have [NightCore](https://nightexpressdev.com/nightcore/) plugin installed to run **ExcellentEnchants**. Minecraft 26.1.2 support requires NightCore 2.15.2 or newer.
 
 The following versions and platforms are supported:
 
 | **Server Version** | **Paper** | **Spigot** | **Folia** | **Java Version** |
 |:------------------:|:---------:|:----------:|:---------:|:----------------:|
-|      1.21.11       |    ✔️     |     ✔️     |     ❌     |        21        |
-|      1.21.10       |    ✔️     |     ✔️     |     ❌     |        21        |
-|       1.21.9       |    ✔️     |     ❌      |     ❌     |        21        |
-|       1.21.8       |    ✔️     |     ✔️     |     ❌     |        21        |
+|       26.1.2       |    Yes    |    Yes     |    No     |        25        |
+|      1.21.11       |    Yes    |    Yes     |    No     |        21        |
+|      1.21.10       |    Yes    |    Yes     |    No     |        21        |
+|       1.21.9       |    Yes    |     No     |    No     |        21        |
+|       1.21.8       |    Yes    |    Yes     |    No     |        21        |
 
 - Anything not listed in the compatibility table is **NOT** supported.
 - Make sure to check out all known issues and incompatibilities [here](https://nightexpressdev.com/excellentenchants/common-issues/).

--- a/compat-mythicmobs/pom.xml
+++ b/compat-mythicmobs/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>su.nightexpress.excellentenchants</groupId>
         <artifactId>ExcellentEnchants</artifactId>
-        <version>5.4.2</version>
+        <version>5.4.3</version>
     </parent>
 
     <artifactId>compat-mythicmobs</artifactId>

--- a/compat-mythicmobs/pom.xml
+++ b/compat-mythicmobs/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>su.nightexpress.excellentenchants</groupId>
         <artifactId>ExcellentEnchants</artifactId>
-        <version>5.4.1</version>
+        <version>5.4.2</version>
     </parent>
 
     <artifactId>compat-mythicmobs</artifactId>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21.10-R0.1-SNAPSHOT</version>
+            <version>26.1.2.build.51-beta</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>su.nightexpress.excellentenchants</groupId>
     <artifactId>ExcellentEnchants</artifactId>
     <packaging>pom</packaging>
-    <version>5.4.2</version>
+    <version>5.4.3</version>
     <modules>
         <module>API</module>
         <module>Core</module>

--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,14 @@
     <groupId>su.nightexpress.excellentenchants</groupId>
     <artifactId>ExcellentEnchants</artifactId>
     <packaging>pom</packaging>
-    <version>5.4.1</version>
+    <version>5.4.2</version>
     <modules>
         <module>API</module>
         <module>Core</module>
         <module>MC_1_21_8</module>
         <module>MC_1_21_10</module>
         <module>spigot-1.21.11</module>
+        <module>spigot-26.1.2</module>
         <module>tooltip-packetevents</module>
         <module>tooltip-protocollib</module>
         <module>compat-mythicmobs</module>
@@ -55,7 +56,7 @@
         <dependency>
             <groupId>su.nightexpress.nightcore</groupId>
             <artifactId>main</artifactId>
-            <version>2.13.2</version>
+            <version>2.15.2</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/spigot-1.21.11/pom.xml
+++ b/spigot-1.21.11/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>su.nightexpress.excellentenchants</groupId>
         <artifactId>ExcellentEnchants</artifactId>
-        <version>5.4.2</version>
+        <version>5.4.3</version>
     </parent>
 
     <artifactId>spigot-1.21.11</artifactId>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>API</artifactId>
-            <version>5.4.2</version>
+            <version>5.4.3</version>
         </dependency>
     </dependencies>
 

--- a/spigot-1.21.11/pom.xml
+++ b/spigot-1.21.11/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>su.nightexpress.excellentenchants</groupId>
         <artifactId>ExcellentEnchants</artifactId>
-        <version>5.4.1</version>
+        <version>5.4.2</version>
     </parent>
 
     <artifactId>spigot-1.21.11</artifactId>
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.21.11-R0.1-SNAPSHOT</version>
+            <version>1.21.11-R0.2-SNAPSHOT</version>
             <classifier>remapped-mojang</classifier>
             <scope>provided</scope>
         </dependency>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>API</artifactId>
-            <version>5.4.1</version>
+            <version>5.4.2</version>
         </dependency>
     </dependencies>
 
@@ -47,9 +47,9 @@
                         </goals>
                         <id>remap-obf</id>
                         <configuration>
-                            <srgIn>org.spigotmc:minecraft-server:1.21.11-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
+                            <srgIn>org.spigotmc:minecraft-server:1.21.11-R0.2-SNAPSHOT:txt:maps-mojang</srgIn>
                             <reverse>true</reverse>
-                            <remappedDependencies>org.spigotmc:spigot:1.21.11-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
+                            <remappedDependencies>org.spigotmc:spigot:1.21.11-R0.2-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
                             <remappedArtifactAttached>true</remappedArtifactAttached>
                             <remappedClassifierName>remapped-obf</remappedClassifierName>
                         </configuration>
@@ -62,8 +62,8 @@
                         <id>remap-spigot</id>
                         <configuration>
                             <inputFile>${project.build.directory}/${project.artifactId}-${project.version}-remapped-obf.jar</inputFile>
-                            <srgIn>org.spigotmc:minecraft-server:1.21.11-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
-                            <remappedDependencies>org.spigotmc:spigot:1.21.11-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
+                            <srgIn>org.spigotmc:minecraft-server:1.21.11-R0.2-SNAPSHOT:csrg:maps-spigot</srgIn>
+                            <remappedDependencies>org.spigotmc:spigot:1.21.11-R0.2-SNAPSHOT:jar:remapped-obf</remappedDependencies>
                         </configuration>
                     </execution>
                 </executions>

--- a/spigot-26.1.2/pom.xml
+++ b/spigot-26.1.2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>su.nightexpress.excellentenchants</groupId>
         <artifactId>ExcellentEnchants</artifactId>
-        <version>5.4.2</version>
+        <version>5.4.3</version>
     </parent>
 
     <artifactId>spigot-26.1.2</artifactId>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>API</artifactId>
-            <version>5.4.2</version>
+            <version>5.4.3</version>
         </dependency>
     </dependencies>
 </project>

--- a/spigot-26.1.2/pom.xml
+++ b/spigot-26.1.2/pom.xml
@@ -9,7 +9,7 @@
         <version>5.4.2</version>
     </parent>
 
-    <artifactId>tooltip-protocollib</artifactId>
+    <artifactId>spigot-26.1.2</artifactId>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
@@ -17,18 +17,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>codemc-releases</id>
-            <url>https://repo.codemc.io/repository/maven-releases/</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
-            <groupId>io.papermc.paper</groupId>
-            <artifactId>paper-api</artifactId>
-            <version>26.1.2.build.51-beta</version>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>26.1.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
@@ -37,13 +30,5 @@
             <artifactId>API</artifactId>
             <version>5.4.2</version>
         </dependency>
-
-        <dependency>
-            <groupId>net.dmulloy2</groupId>
-            <artifactId>ProtocolLib</artifactId>
-            <version>5.4.0</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
-
 </project>

--- a/spigot-26.1.2/src/main/java/su/nightexpress/excellentenchants/nms/mc_26_1_2/RegistryHack_26_1_2.java
+++ b/spigot-26.1.2/src/main/java/su/nightexpress/excellentenchants/nms/mc_26_1_2/RegistryHack_26_1_2.java
@@ -1,4 +1,4 @@
-package su.nightexpress.excellentenchants.nms.mc_1_21_11;
+package su.nightexpress.excellentenchants.nms.mc_26_1_2;
 
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderSet;
@@ -17,20 +17,20 @@ import net.minecraft.world.flag.FeatureFlags;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.enchantment.Enchantment;
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_21_R7.CraftEquipmentSlot;
-import org.bukkit.craftbukkit.v1_21_R7.CraftServer;
-import org.bukkit.craftbukkit.v1_21_R7.enchantments.CraftEnchantment;
-import org.bukkit.craftbukkit.v1_21_R7.util.CraftChatMessage;
-import org.bukkit.craftbukkit.v1_21_R7.util.CraftNamespacedKey;
+import org.bukkit.craftbukkit.CraftEquipmentSlot;
+import org.bukkit.craftbukkit.CraftServer;
+import org.bukkit.craftbukkit.enchantments.CraftEnchantment;
+import org.bukkit.craftbukkit.util.CraftChatMessage;
+import org.bukkit.craftbukkit.util.CraftNamespacedKey;
 import org.bukkit.inventory.EquipmentSlot;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import su.nightexpress.excellentenchants.EnchantsKeys;
+import su.nightexpress.excellentenchants.api.EnchantDefinition;
+import su.nightexpress.excellentenchants.api.EnchantDistribution;
 import su.nightexpress.excellentenchants.api.enchantment.CustomEnchantment;
 import su.nightexpress.excellentenchants.api.item.ItemSet;
 import su.nightexpress.excellentenchants.api.wrapper.EnchantCost;
-import su.nightexpress.excellentenchants.api.EnchantDefinition;
-import su.nightexpress.excellentenchants.api.EnchantDistribution;
 import su.nightexpress.excellentenchants.api.wrapper.TradeType;
 import su.nightexpress.excellentenchants.bridge.DistributionSettings;
 import su.nightexpress.excellentenchants.bridge.EnchantCatalogEntry;
@@ -42,17 +42,18 @@ import su.nightexpress.nightcore.util.text.night.NightMessage;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
-public class RegistryHack_1_21_11 implements RegistryHack {
+public class RegistryHack_26_1_2 implements RegistryHack {
 
     private static final MinecraftServer             SERVER;
     private static final MappedRegistry<Enchantment> ENCHANTS;
     private static final MappedRegistry<Item>        ITEMS;
 
-    private static final String REGISTRY_FROZEN_TAGS_FIELD = "j"; // frozenTags
-    private static final String REGISTRY_ALL_TAGS_FIELD    = "k"; // allTags
-    private static final String TAG_SET_UNBOUND_METHOD     = "a"; // .unbound()
-    private static final String TAG_SET_MAP_FIELD          = "a"; // val$map for PaperMC
+    private static final String REGISTRY_FROZEN_TAGS_FIELD = "frozenTags";
+    private static final String REGISTRY_ALL_TAGS_FIELD    = "allTags";
+    private static final String TAG_SET_UNBOUND_METHOD     = "unbound";
+    private static final String TAG_SET_MAP_FIELD          = "val$tags";
 
     static {
         SERVER = ((CraftServer) Bukkit.getServer()).getServer();
@@ -62,7 +63,7 @@ public class RegistryHack_1_21_11 implements RegistryHack {
 
     private final NightPlugin plugin;
 
-    public RegistryHack_1_21_11(@NotNull NightPlugin plugin) {
+    public RegistryHack_26_1_2(@NotNull NightPlugin plugin) {
         this.plugin = plugin;
     }
 
@@ -88,6 +89,10 @@ public class RegistryHack_1_21_11 implements RegistryHack {
 
     private static TagKey<Item> customItemsTag(String path) {
         return TagKey.create(ITEMS.key(), customIdentifier(path));
+    }
+
+    private static TagKey<Enchantment> tradeTag(String path) {
+        return TagKey.create(ENCHANTS.key(), Identifier.withDefaultNamespace("trades/" + path));
     }
 
     @SuppressWarnings("unchecked")
@@ -119,8 +124,8 @@ public class RegistryHack_1_21_11 implements RegistryHack {
     }
 
     private static <T> void unfreeze(MappedRegistry<T> registry) {
-        Reflex.setFieldValue(registry, "l", false);             // MappedRegistry#frozen
-        Reflex.setFieldValue(registry, "m", new IdentityHashMap<>()); // MappedRegistry#unregisteredIntrusiveHolders
+        Reflex.setFieldValue(registry, "frozen", false);
+        Reflex.setFieldValue(registry, "unregisteredIntrusiveHolders", new IdentityHashMap<>());
     }
 
     private static <T> void freeze(MappedRegistry<T> registry) {
@@ -158,7 +163,7 @@ public class RegistryHack_1_21_11 implements RegistryHack {
     }
 
     private static <T> void unbound(MappedRegistry<T> registry) {
-        Class<?> tagSetClass = Reflex.safeInnerClass(MappedRegistry.class.getName(), "a");  // TagSet for PaperMC
+        Class<?> tagSetClass = Reflex.safeInnerClass(MappedRegistry.class.getName(), "TagSet");
 
         Method unboundMethod = Reflex.safeMethod(tagSetClass, TAG_SET_UNBOUND_METHOD);
         Object unboundTagSet = Reflex.invokeMethod(unboundMethod, registry); // new TagSet object.
@@ -254,8 +259,8 @@ public class RegistryHack_1_21_11 implements RegistryHack {
         // Any enchantment can be tradable.
         if (experimentalTrades) {
             if (distribution.isTradable() && settings.isTradingEnabled()) {
-                distribution.getTrades().forEach(tradeType -> {
-                    addInTag(getTradeKey(tradeType), reference);
+                distribution.getTrades().stream().map(RegistryHack_26_1_2::getTradeKey).collect(Collectors.toSet()).forEach(tradeKey -> {
+                    addInTag(tradeKey, reference);
                 });
             }
         }
@@ -281,7 +286,9 @@ public class RegistryHack_1_21_11 implements RegistryHack {
     }
 
     private void addInTag(TagKey<Enchantment> tagKey, Holder.Reference<Enchantment> reference) {
-        modfiyTag(ENCHANTS, tagKey, reference, List::add);
+        modfiyTag(ENCHANTS, tagKey, reference, (contents, holder) -> {
+            if (!contents.contains(holder)) contents.add(holder);
+        });
     }
 
     private void removeFromTag(TagKey<Enchantment> tagKey, Holder.Reference<Enchantment> reference) {
@@ -302,7 +309,7 @@ public class RegistryHack_1_21_11 implements RegistryHack {
         List<Holder<T>> contents = new ArrayList<>(holders.stream().toList());
         consumer.accept(contents, reference);
 
-        registry.bindTag(tagKey, contents);
+        bindTag(registry, tagKey, contents);
     }
 
     @Override
@@ -319,7 +326,7 @@ public class RegistryHack_1_21_11 implements RegistryHack {
         });
 
         // Creates new tag, puts it in the 'frozenTags' map and binds holders to it.
-        ITEMS.bindTag(tag, holders);
+        bindTag(ITEMS, tag, holders);
 
         //return getFrozenTags(ITEMS).get(customKey);
     }
@@ -329,30 +336,24 @@ public class RegistryHack_1_21_11 implements RegistryHack {
         List<Holder<Enchantment>> holders = new ArrayList<>();
 
         // Creates new tag, puts it in the 'frozenTags' map and binds holders to it.
-        ENCHANTS.bindTag(customKey, holders);
+        bindTag(ENCHANTS, customKey, holders);
 
         return getFrozenTags(ENCHANTS).get(customKey);
     }
 
-
-
+    private static <T> void bindTag(MappedRegistry<T> registry, TagKey<T> tagKey, List<Holder<T>> holders) {
+        registry.bindTags(Map.of(tagKey, holders));
+    }
 
     private static TagKey<Enchantment> getTradeKey(TradeType tradeType) {
         return switch (tradeType) {
-            case DESERT_COMMON -> EnchantmentTags.TRADES_DESERT_COMMON;
-            case DESERT_SPECIAL -> EnchantmentTags.TRADES_DESERT_SPECIAL;
-            case PLAINS_COMMON -> EnchantmentTags.TRADES_PLAINS_COMMON;
-            case PLAINS_SPECIAL -> EnchantmentTags.TRADES_PLAINS_SPECIAL;
-            case SAVANNA_COMMON -> EnchantmentTags.TRADES_SAVANNA_COMMON;
-            case SAVANNA_SPECIAL -> EnchantmentTags.TRADES_SAVANNA_SPECIAL;
-            case JUNGLE_COMMON -> EnchantmentTags.TRADES_JUNGLE_COMMON;
-            case JUNGLE_SPECIAL -> EnchantmentTags.TRADES_JUNGLE_SPECIAL;
-            case SNOW_COMMON -> EnchantmentTags.TRADES_SNOW_COMMON;
-            case SNOW_SPECIAL -> EnchantmentTags.TRADES_SNOW_SPECIAL;
-            case SWAMP_COMMON -> EnchantmentTags.TRADES_SWAMP_COMMON;
-            case SWAMP_SPECIAL -> EnchantmentTags.TRADES_SWAMP_SPECIAL;
-            case TAIGA_COMMON -> EnchantmentTags.TRADES_TAIGA_COMMON;
-            case TAIGA_SPECIAL -> EnchantmentTags.TRADES_TAIGA_SPECIAL;
+            case DESERT_COMMON, DESERT_SPECIAL -> tradeTag("desert_common");
+            case PLAINS_COMMON, PLAINS_SPECIAL -> tradeTag("plains_common");
+            case SAVANNA_COMMON, SAVANNA_SPECIAL -> tradeTag("savanna_common");
+            case JUNGLE_COMMON, JUNGLE_SPECIAL -> tradeTag("jungle_common");
+            case SNOW_COMMON, SNOW_SPECIAL -> tradeTag("snow_common");
+            case SWAMP_COMMON, SWAMP_SPECIAL -> tradeTag("swamp_common");
+            case TAIGA_COMMON, TAIGA_SPECIAL -> tradeTag("taiga_common");
         };
     }
 

--- a/tooltip-packetevents/pom.xml
+++ b/tooltip-packetevents/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>su.nightexpress.excellentenchants</groupId>
         <artifactId>ExcellentEnchants</artifactId>
-        <version>5.4.1</version>
+        <version>5.4.2</version>
     </parent>
 
     <artifactId>tooltip-packetevents</artifactId>
@@ -28,14 +28,14 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21.10-R0.1-SNAPSHOT</version>
+            <version>26.1.2.build.51-beta</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>API</artifactId>
-            <version>5.4.1</version>
+            <version>5.4.2</version>
         </dependency>
 
         <dependency>

--- a/tooltip-packetevents/pom.xml
+++ b/tooltip-packetevents/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>su.nightexpress.excellentenchants</groupId>
         <artifactId>ExcellentEnchants</artifactId>
-        <version>5.4.2</version>
+        <version>5.4.3</version>
     </parent>
 
     <artifactId>tooltip-packetevents</artifactId>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>API</artifactId>
-            <version>5.4.2</version>
+            <version>5.4.3</version>
         </dependency>
 
         <dependency>

--- a/tooltip-protocollib/pom.xml
+++ b/tooltip-protocollib/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>su.nightexpress.excellentenchants</groupId>
         <artifactId>ExcellentEnchants</artifactId>
-        <version>5.4.2</version>
+        <version>5.4.3</version>
     </parent>
 
     <artifactId>tooltip-protocollib</artifactId>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>su.nightexpress.excellentenchants</groupId>
             <artifactId>API</artifactId>
-            <version>5.4.2</version>
+            <version>5.4.3</version>
         </dependency>
 
         <dependency>

--- a/tooltip-protocollib/src/main/java/su/nightexpress/excellentenchants/tooltip/handler/ProtocolTooltipHandler.java
+++ b/tooltip-protocollib/src/main/java/su/nightexpress/excellentenchants/tooltip/handler/ProtocolTooltipHandler.java
@@ -79,6 +79,7 @@ public class ProtocolTooltipHandler implements TooltipHandler {
             PacketContainer packet = event.getPacket();
             Player player = event.getPlayer();
 
+            if (player == null || event.isPlayerTemporary()) return;
             if (!this.controller.isReadyForTooltipUpdate(player)) return;
 
             PacketType type = packet.getType();


### PR DESCRIPTION
Added Minecraft 26.1.2 compatibility for ExcellentEnchants. This includes a new Spigot 26.1.2 registry module, updated Paper/Spigot dependencies, NightCore 2.15.2 support, dynamic trade-tag handling for removed special villager trade tags, safe spear item tag lookup, and smoke-tested Paper/Spigot 26.1.2 startup without breaking Paper 1.21.11 or 1.21.8.